### PR TITLE
Add GZIP Header

### DIFF
--- a/src/OddsClient.php
+++ b/src/OddsClient.php
@@ -31,7 +31,8 @@ class OddsClient
         $this->client = new Client([
             'base_uri' => $this->apiEndpoint,
             'headers' => [
-                'Content-Type' => 'application/json'
+                'Content-Type' => 'application/json',
+                'Accept-Encoding' => 'gzip',
             ]
         ]);
 


### PR DESCRIPTION
This PR updates the Guzzle client configuration in `OddsClient.php` to include the `Accept-Encoding: gzip` header. This enables HTTP response compression, reducing payload size and improving response times when interacting with the API.